### PR TITLE
Authorization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ redis = "0.15"
 r2d2 = "0.8"
 scheduled-thread-pool = "0.2"
 serde_json = "1.0"
-reqwest = { version = "0.10", features = ["json"] }
+reqwest = { version = "0.10", features = ["json", "blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 sqlx = { version = "0.3", default-features = false, features = [ "sqlite", "runtime-tokio", "macros" ] }
 async-trait = "0.1.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ redis = "0.15"
 r2d2 = "0.8"
 scheduled-thread-pool = "0.2"
 serde_json = "1.0"
+reqwest = { version = "0.10", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 sqlx = { version = "0.3", default-features = false, features = [ "sqlite", "runtime-tokio", "macros" ] }
 async-trait = "0.1.30"
@@ -25,6 +26,7 @@ dirs = "2.0.2"
 ed25519-dalek = "1.0.0-pre.3"
 hex = "0.4"
 bip39 = "0.6.0-beta.1"
+futures = "0.3.4"
 
 [build-dependencies]
 bindgen = "0.53"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ ed25519-dalek = "1.0.0-pre.3"
 hex = "0.4"
 bip39 = "0.6.0-beta.1"
 futures = "0.3.4"
+base64 = "0.12.0"
 
 [build-dependencies]
 bindgen = "0.53"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ redis = "0.15"
 r2d2 = "0.8"
 scheduled-thread-pool = "0.2"
 serde_json = "1.0"
-reqwest = { version = "0.10", features = ["json", "blocking"] }
+surf = "1.0.3"
+url = "2.1.1"
 serde = { version = "1.0", features = ["derive"] }
 sqlx = { version = "0.3", default-features = false, features = [ "sqlite", "runtime-tokio", "macros" ] }
 async-trait = "0.1.30"

--- a/clients/go/bcdb/auth.go
+++ b/clients/go/bcdb/auth.go
@@ -1,0 +1,95 @@
+package bcdb
+
+import (
+	"bytes"
+	context "context"
+	"crypto/ed25519"
+	"encoding/base64"
+	fmt "fmt"
+	"time"
+
+	"github.com/tyler-smith/go-bip39"
+	"google.golang.org/grpc/credentials"
+)
+
+// AuthOption set some optional config on the authenticator
+type AuthOption interface {
+	set(*authImpl)
+}
+
+type authOptionFn func(*authImpl)
+
+func (f authOptionFn) set(a *authImpl) {
+	f(a)
+}
+
+// WithExpiresDuration sets expiration duration
+func WithExpiresDuration(d time.Duration) AuthOption {
+	return authOptionFn(func(a *authImpl) {
+		a.expires = d
+	})
+}
+
+type authImpl struct {
+	id      uint64
+	privKey ed25519.PrivateKey
+	expires time.Duration
+}
+
+// NewBCDBAuthenticator creates a new credentials.PerRPCCredentials
+func NewBCDBAuthenticator(id uint64, seed []byte, opt ...AuthOption) (credentials.PerRPCCredentials, error) {
+	if len(seed) != ed25519.SeedSize {
+		return nil, fmt.Errorf("seed has the wrong size %d", len(seed))
+	}
+
+	privateKey := ed25519.NewKeyFromSeed(seed)
+
+	a := &authImpl{
+		id:      id,
+		privKey: privateKey,
+		expires: 3 * time.Second,
+	}
+
+	for _, o := range opt {
+		o.set(a)
+	}
+
+	return a, nil
+}
+
+// NewBCDBAuthenticatorFromMnemonic creates a new credentials.PerRPCCredentials
+func NewBCDBAuthenticatorFromMnemonic(id uint64, mnemonic string, opt ...AuthOption) (credentials.PerRPCCredentials, error) {
+	seed, err := bip39.EntropyFromMnemonic(mnemonic)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewBCDBAuthenticator(id, seed, opt...)
+
+}
+
+func (a *authImpl) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	created := time.Now()
+	expires := created.Add(a.expires)
+	var buf bytes.Buffer
+
+	buf.WriteString(fmt.Sprintf("(created): %d\n", created.Unix()))
+	buf.WriteString(fmt.Sprintf("(expires): %d\n", expires.Unix()))
+	buf.WriteString(fmt.Sprintf("(key-id): %d", a.id))
+
+	signature := base64.RawStdEncoding.EncodeToString(ed25519.Sign(a.privKey, buf.Bytes()))
+
+	s := `Signature keyId="%d",algorithm="hs2019",created="%d",expires="%d",headers="(created) (expires) (key-id)", signature="%s"`
+
+	s = fmt.Sprintf(s, a.id, created.Unix(), expires.Unix(), signature)
+
+	values := map[string]string{
+		"Authorization": s,
+	}
+
+	return values, nil
+}
+
+func (a *authImpl) RequireTransportSecurity() bool {
+	return false
+}

--- a/clients/go/example.go
+++ b/clients/go/example.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 
+	"time"
+
 	"example.com/test/bcdb"
 	"google.golang.org/grpc"
 )
@@ -13,8 +15,12 @@ type Authenticator struct {
 }
 
 func (a *Authenticator) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	s := `Signature keyId="6",algorithm="hs2019",created="%d",expires="%d",headers="(created) (expires) (key-id)", signature="Base64(RSA-SHA512(signing string))"`
+	n := time.Now()
+	s = fmt.Sprintf(s, n.Unix(), n.Add(3*time.Second).Unix())
+
 	values := map[string]string{
-		"Authorization": `Signature keyId="rsa-key-1",algorithm="hs2019",headers="(request-target) (created) host digest content-length", signature="Base64(RSA-SHA512(signing string))"`,
+		"Authorization": s,
 	}
 	return values, nil
 }

--- a/clients/go/example.go
+++ b/clients/go/example.go
@@ -11,62 +11,54 @@ import (
 	"google.golang.org/grpc"
 )
 
-type Authenticator struct {
-}
-
-func (a *Authenticator) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
-	s := `Signature keyId="6",algorithm="hs2019",created="%d",expires="%d",headers="(created) (expires) (key-id)", signature="Base64(RSA-SHA512(signing string))"`
-	n := time.Now()
-	s = fmt.Sprintf(s, n.Unix(), n.Add(3*time.Second).Unix())
-
-	values := map[string]string{
-		"Authorization": s,
-	}
-	return values, nil
-}
-
-func (a *Authenticator) RequireTransportSecurity() bool {
-	return false
-}
-
 func main() {
-	client, err := grpc.Dial("localhost:50051", grpc.WithInsecure(), grpc.WithPerRPCCredentials(&Authenticator{}))
+	const (
+		userID   = 6
+		mnemonic = "hawk flush rifle build globe festival process enrich angry okay inmate pilot reunion february best health pigeon actor spare absurd glory ahead situate float"
+	)
+
+	auth, err := bcdb.NewBCDBAuthenticatorFromMnemonic(userID, mnemonic, bcdb.WithExpiresDuration(3*time.Second))
+	if err != nil {
+		panic(err)
+	}
+
+	client, err := grpc.Dial("localhost:50051", grpc.WithInsecure(), grpc.WithPerRPCCredentials(auth))
 	if err != nil {
 		panic(err)
 	}
 
 	cl := bcdb.NewBCDBClient(client)
 
-	// name := fmt.Sprintf("test-file-name-%d", time.Now().Unix())
-	// req := bcdb.SetRequest{
-	// 	Data: []byte("hello world"),
-	// 	Metadata: &bcdb.Metadata{
-	// 		Acl:        &bcdb.AclRef{Acl: 100},
-	// 		Collection: "files",
-	// 		Tags: []*bcdb.Tag{
-	// 			{
-	// 				Key:   "name",
-	// 				Value: name,
-	// 			},
-	// 			{
-	// 				Key:   "dir",
-	// 				Value: "/path/to/file",
-	// 			},
-	// 			{
-	// 				Key:   "type",
-	// 				Value: "file",
-	// 			},
-	// 		},
-	// 	},
-	// }
+	name := fmt.Sprintf("test-file-name-%d", time.Now().Unix())
+	req := bcdb.SetRequest{
+		Data: []byte("hello world"),
+		Metadata: &bcdb.Metadata{
+			Acl:        &bcdb.AclRef{Acl: 100},
+			Collection: "files",
+			Tags: []*bcdb.Tag{
+				{
+					Key:   "name",
+					Value: name,
+				},
+				{
+					Key:   "dir",
+					Value: "/path/to/file",
+				},
+				{
+					Key:   "type",
+					Value: "file",
+				},
+			},
+		},
+	}
 
-	// response, err := cl.Set(context.TODO(), &req)
-	// if err != nil {
-	// 	panic(err)
-	// }
+	response, err := cl.Set(context.TODO(), &req)
+	if err != nil {
+		panic(err)
+	}
 
-	// id := response.GetId()
-	// fmt.Println("ID:", id)
+	id := response.GetId()
+	fmt.Println("ID:", id)
 
 	list, err := cl.Find(context.TODO(), &bcdb.QueryRequest{
 		Collection: "files",

--- a/clients/go/example.go
+++ b/clients/go/example.go
@@ -4,50 +4,63 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"time"
 
 	"example.com/test/bcdb"
 	"google.golang.org/grpc"
 )
 
+type Authenticator struct {
+}
+
+func (a *Authenticator) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	values := map[string]string{
+		"Authorization": `Signature keyId="rsa-key-1",algorithm="hs2019",headers="(request-target) (created) host digest content-length", signature="Base64(RSA-SHA512(signing string))"`,
+	}
+	return values, nil
+}
+
+func (a *Authenticator) RequireTransportSecurity() bool {
+	return false
+}
+
 func main() {
-	client, err := grpc.Dial("localhost:50051", grpc.WithInsecure())
+	client, err := grpc.Dial("localhost:50051", grpc.WithInsecure(), grpc.WithPerRPCCredentials(&Authenticator{}))
 	if err != nil {
 		panic(err)
 	}
 
 	cl := bcdb.NewBCDBClient(client)
 
-	name := fmt.Sprintf("test-file-name-%d", time.Now().Unix())
-	req := bcdb.SetRequest{
-		Data: []byte("hello world"),
-		Metadata: &bcdb.Metadata{
-			Acl:        &bcdb.AclRef{Acl: 100},
-			Collection: "files",
-			Tags: []*bcdb.Tag{
-				{
-					Key:   "name",
-					Value: name,
-				},
-				{
-					Key:   "dir",
-					Value: "/path/to/file",
-				},
-				{
-					Key:   "type",
-					Value: "file",
-				},
-			},
-		},
-	}
+	// name := fmt.Sprintf("test-file-name-%d", time.Now().Unix())
+	// req := bcdb.SetRequest{
+	// 	Data: []byte("hello world"),
+	// 	Metadata: &bcdb.Metadata{
+	// 		Acl:        &bcdb.AclRef{Acl: 100},
+	// 		Collection: "files",
+	// 		Tags: []*bcdb.Tag{
+	// 			{
+	// 				Key:   "name",
+	// 				Value: name,
+	// 			},
+	// 			{
+	// 				Key:   "dir",
+	// 				Value: "/path/to/file",
+	// 			},
+	// 			{
+	// 				Key:   "type",
+	// 				Value: "file",
+	// 			},
+	// 		},
+	// 	},
+	// }
 
-	response, err := cl.Set(context.TODO(), &req)
-	if err != nil {
-		panic(err)
-	}
+	// response, err := cl.Set(context.TODO(), &req)
+	// if err != nil {
+	// 	panic(err)
+	// }
 
-	id := response.GetId()
-	fmt.Println("ID:", id)
+	// id := response.GetId()
+	// fmt.Println("ID:", id)
 
 	list, err := cl.Find(context.TODO(), &bcdb.QueryRequest{
 		Collection: "files",

--- a/clients/go/go.mod
+++ b/clients/go/go.mod
@@ -4,5 +4,6 @@ go 1.13
 
 require (
 	github.com/golang/protobuf v1.3.5
+	github.com/tyler-smith/go-bip39 v1.0.2
 	google.golang.org/grpc v1.28.0
 )

--- a/clients/go/go.sum
+++ b/clients/go/go.sum
@@ -15,6 +15,9 @@ github.com/golang/protobuf v1.3.5 h1:F768QJ1E9tib+q5Sc8MkdJi1RxLTbRcTf8LJV56aRls
 github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/tyler-smith/go-bip39 v1.0.2 h1:+t3w+KwLXO6154GNJY+qUtIxLTmFjfUmpguQT1OlOT8=
+github.com/tyler-smith/go-bip39 v1.0.2/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,197 @@
+use failure::Error;
+use reqwest::{Client, Url};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tonic::{Request, Status};
+
+const BASE_URL: &str = "https://explorer.devnet.grid.tf/explorer/users/";
+
+pub struct Authenticator {
+    client: Client,
+    base_url: Url,
+    cache: Arc<Mutex<HashMap<u64, String>>>,
+}
+
+#[derive(Deserialize)]
+struct User {
+    pub pubkey: String,
+}
+
+impl Authenticator {
+    pub fn new(base: Option<&str>) -> Result<Authenticator, Error> {
+        Ok(Authenticator {
+            base_url: match base {
+                Some(base) => base,
+                None => BASE_URL,
+            }
+            .parse()?,
+            client: Client::new(),
+            cache: Arc::new(Mutex::new(HashMap::new())),
+        })
+    }
+
+    async fn get_key(&self, id: u64) -> Result<String, Error> {
+        let mut cache = self.cache.lock().await;
+        if let Some(key) = cache.get(&id) {
+            return Ok(key.into());
+        }
+
+        let url = self.base_url.join(&format!("{}", id))?;
+        let resp: User = self.client.get(url).send().await?.json().await?;
+        cache.insert(id, resp.pubkey.clone());
+
+        Ok(resp.pubkey)
+    }
+
+    pub async fn authenticate<T>(&self, request: Request<T>) -> Result<Request<T>, Status> {
+        let meta = request.metadata();
+        for p in meta.iter() {
+            println!("{:?}", p);
+        }
+
+        let header: AuthHeader = match meta.get("authorization") {
+            None => return Err(Status::unauthenticated("missing authorization header")),
+            Some(v) => match v.to_str().unwrap().parse() {
+                Ok(header) => header,
+                Err(err) => {
+                    return Err(Status::unauthenticated(format!(
+                        "invalid auth header: {}",
+                        err
+                    )))
+                }
+            },
+        };
+
+        debug!("Auth header: {:?}", header);
+
+        Ok(request)
+    }
+}
+
+#[derive(Debug)]
+struct AuthHeader {
+    keyId: String,
+    algorithm: String,
+    headers: String,
+    signature: String,
+}
+
+impl FromStr for AuthHeader {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        const PREFIX: &str = "Signature ";
+        enum Mode {
+            Key,
+            ValueStart,
+            Value,
+            Next,
+        }
+        match s.find(PREFIX) {
+            Some(0) => (),
+            _ => bail!("header is not starting with `Signature`"),
+        };
+        let mut mode = Mode::Key;
+        let mut key = String::new();
+        let mut value = String::new();
+
+        let mut map: HashMap<String, String> = HashMap::new();
+        //let mut previous = Mode::Unknown;
+        for c in s[PREFIX.len()..].chars() {
+            match mode {
+                Mode::Key => {
+                    if c == '=' {
+                        mode = Mode::ValueStart;
+                        continue;
+                    }
+
+                    key.push(c)
+                }
+                Mode::ValueStart => {
+                    if c != '"' {
+                        bail!("invalid value not starting with '\"'");
+                    }
+                    mode = Mode::Value;
+                }
+                Mode::Value => {
+                    //TODO: skip sequence?
+                    if c == '"' {
+                        map.insert(key.trim().into(), value.clone());
+                        key.clear();
+                        value.clear();
+
+                        mode = Mode::Next;
+                        continue;
+                    }
+                    value.push(c)
+                }
+                Mode::Next => {
+                    if c == ',' {
+                        mode = Mode::Key
+                    }
+                }
+            }
+        }
+        Ok(AuthHeader {
+            keyId: map
+                .get("keyId")
+                .ok_or(format_err!("missing KeyId value in Authorization"))?
+                .into(),
+            headers: map
+                .get("headers")
+                .ok_or(format_err!("missing headers value in Authorization"))?
+                .into(),
+            algorithm: map
+                .get("algorithm")
+                .ok_or(format_err!("missing algorithm value in Authorization"))?
+                .into(),
+            signature: map
+                .get("signature")
+                .ok_or(format_err!("missing signature value in Authorization"))?
+                .into(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn get_user_key() {
+        let auth = Authenticator::new(None).unwrap();
+        match auth.get_key(1).await {
+            Ok(key) => println!("pubkey: {}", key),
+            Err(err) => panic!(err), //assert_eq!(true, false, "failed to get user id: {}", err),
+        };
+
+        assert_eq!(auth.cache.lock().await.len(), 1);
+    }
+    #[test]
+    fn auth_header_parse() {
+        let auth: AuthHeader = "Signature keyId=\"rsa-key-1\",algorithm=\"hs2019\",
+        headers=\"(request-target) (created) host digest content-length\",
+        signature=\"Base64(RSA-SHA512(signing string))\""
+            .parse()
+            .unwrap();
+
+        assert_eq!(auth.algorithm, "hs2019");
+        assert_eq!(auth.keyId, "rsa-key-1");
+        assert_eq!(auth.signature, "Base64(RSA-SHA512(signing string))");
+        assert_eq!(
+            auth.headers,
+            "(request-target) (created) host digest content-length"
+        )
+    }
+    #[test]
+    fn auth_header_parse_missing_value() {
+        let auth: Result<AuthHeader, Error> = "Signature keyId=\"rsa-key-1\",algorithm=\"hs2019\",
+        headers=\"(request-target) (created) host digest content-length\""
+            .parse();
+
+        assert_eq!(auth.is_err(), true);
+        auth.expect_err("missing signature value in Authorization");
+    }
+}

--- a/src/identity/ed25519.rs
+++ b/src/identity/ed25519.rs
@@ -19,7 +19,7 @@ pub struct Identity {
 
 /// A stand alone public key, which can be used to verify signatures made with the associated
 /// private key.
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct PublicKey {
     pk: PubKey,
 }
@@ -124,6 +124,12 @@ impl<'de> Deserialize<'de> for PublicKey {
         } else {
             deserializer.deserialize_bytes(PublicKeyVisitor)
         }
+    }
+}
+
+impl std::fmt::Display for PublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", hex::encode(self.pk.as_bytes()))
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,9 +128,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let a = auth::Authenticator::new(None)?;
 
     Server::builder()
-        .add_service(bcdb::BcdbServer::with_interceptor(bcdb_service, move |r| {
-            futures::executor::block_on(a.authenticate(r))
-        }))
+        .add_service(bcdb::BcdbServer::with_interceptor(
+            bcdb_service,
+            move |request| a.authenticate_blocking(request),
+        ))
         //.add_service(bcdb::BcdbServer::new(bcdb_service))
         .add_service(bcdb::AclServer::new(acl_service))
         .serve(addr)

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .required_unless("seed")
                 .env("SEED_FILE"),
         )
+        .arg(
+            Arg::with_name("explorer")
+                .help("explorer URL for phonebook entries validations")
+                .long("explorer")
+                .takes_value(true)
+                .default_value("https://explorer.devnet.grid.tf/explorer/"),
+        )
         .get_matches();
 
     let level = if matches.is_present("debug") {
@@ -107,7 +114,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // show the bytes
     debug!(
         "Starting server with identity, public key {}",
-        hex::encode(id.public_key().as_bytes())
+        id.public_key()
     );
     debug!("Using identity private key as symmetric encryption key for zdb data");
 
@@ -125,7 +132,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let acl_service = bcdb::AclService::new(acl_store);
 
     let addr = matches.value_of("listen").unwrap().parse()?;
-    let a = auth::Authenticator::new(None)?;
+    let a = auth::Authenticator::new(matches.value_of("explorer"), Some(id.public_key()))?;
 
     Server::builder()
         .add_service(bcdb::BcdbServer::with_interceptor(


### PR DESCRIPTION
- Currently only the go example has been updated to do authentication, same request signing mechanism must be implemented for the python (and javascript?) calls
- Owner of the bcdb instance is auto detected when he do a call, and is then marked as `owner`
- Currently all bcdb calls requires `owner` privilege. This will remain true to all ACL operations, and also List, and Find operations.
- Set, Get operations will change in the near future to actually respect the configured ACLs.